### PR TITLE
Declare settings link loop index

### DIFF
--- a/src/Settings.svelte
+++ b/src/Settings.svelte
@@ -61,7 +61,7 @@ const updateLinks = async (event) => {
   form.reset()
   let links = []
 
-  for (i=0; i < Math.max(numLinks, user.links.length); i++) {
+  for (let i = 0; i < Math.max(numLinks, user.links.length); i++) {
     if (formData.get(`link-name${i}`) != "" && formData.get(`link-url${i}`) != "" && formData.get(`link-name${i}`) != null && formData.get(`link-url${i}`) != null) {
       links.push({name: formData.get(`link-name${i}`), url: formData.get(`link-url${i}`)})
     }


### PR DESCRIPTION
Bugfix for the $1 bug/PR bounty.

The settings page social-link save loop used `i` without declaring it. In strict module code this can throw instead of saving links. This declares the loop index locally so saving social links does not rely on an implicit global.

Tests:
- `git diff --check`
- `npm run build -- --silent` blocked locally: dependencies are not installed, so `rollup` is unavailable in PATH.

/claim