### PR TITLE
Use currentTarget for comment deletion

### DIFF
--- a/src/Comment.svelte
+++ b/src/Comment.svelte
@@ -14,7 +14,7 @@
 
   const removeComment = async (event) => {
     event.preventDefault()
-    const { srcElement: { id: commentId } } = event
+    const { id: commentId } = event.currentTarget
 
     const url = `API_BASE_URL/post/${id}/${commentId}`
     const token = localStorage.getItem('token')


### PR DESCRIPTION
Bugfix for the $1 bug/PR bounty.

Comment deletion used the non-standard `event.srcElement` property to read the clicked comment id. Safari/Firefox can omit or handle that differently. This switches to `event.currentTarget.id`, which points at the element with the click handler.

Tests:
- `git diff --check`
- `npm run build -- --silent` blocked locally: dependencies are not installed, so `rollup` is unavailable in PATH.

/claim