### PR TITLE
Fetch settings user once on mount

### DIFF
--- a/src/Settings.svelte
+++ b/src/Settings.svelte
@@ -4,7 +4,6 @@ import { userStore } from './store'
 import { onMount } from 'svelte'
 
 let user
-$: fetchMe();
 let isEditingFieldBT = false;
 let isEditingFieldLinks = false;
 let numLinks = 1;
@@ -96,6 +95,8 @@ const updateLinks = async (event) => {
     user = await res.json();
     userStore.set(user);
   }
+
+  onMount(fetchMe)
 
 </script>
 


### PR DESCRIPTION
Bugfix for the $1 bug/PR bounty.

The settings page used `$: fetchMe()`, and `fetchMe` assigns `user` after every response. That can retrigger the reactive statement repeatedly, causing unnecessary repeated /me requests. This changes the refresh to run once on mount.

Tests:
- `git diff --check`
- `npm run build -- --silent` blocked locally: dependencies are not installed, so `rollup` is unavailable in PATH.

/claim