### PR TITLE
Fetch sidebar user once on mount

### DIFF
--- a/src/Sidebar.svelte
+++ b/src/Sidebar.svelte
@@ -44,6 +44,7 @@
     cats = await res.json()
     categories.set(cats)
     filtered = cats;
+    fetchMe();
   })
 
   const fetchMe = async () => {
@@ -63,7 +64,6 @@
     userStore.set(user);
   }
   
-  $: fetchMe();
 </script>
 
 <style>


### PR DESCRIPTION
Bugfix for the $1 bug/PR bounty.

The sidebar used `$: fetchMe()`, and `fetchMe` assigns `user` after every response. That can retrigger the reactive statement and repeatedly request /me. This runs the refresh once after the sidebar mounts instead.

Tests:
- `git diff --check`
- `npm run build -- --silent` blocked locally: dependencies are not installed, so `rollup` is unavailable in PATH.

/claim