### PR TITLE
Fetch home user once on mount

### DIFF
--- a/src/Home.svelte
+++ b/src/Home.svelte
@@ -117,6 +117,8 @@
     userStore.set(user);
   }
 
+  onMount(fetchMe)
+
 const sorter = () => {
     const urlParams = new URLSearchParams(window.location.search)
     if (urlParams.get('sort')) type = urlParams.get('sort')
@@ -140,7 +142,6 @@ const sorter = () => {
   $: fetchPost({ type, username, category, page, $activeRoute })
   $: fetchCategory(category)
   $: fetchUser(username);
-  $: fetchMe();
 </script>
 <style>
   .load-more {


### PR DESCRIPTION
Bugfix for the $1 bug/PR bounty.

The home page used `$: fetchMe()`, and `fetchMe` assigns `user` after every /me response. That can retrigger the reactive statement repeatedly. This changes the current-user refresh to run once on mount.

Tests:
- `git diff --check`
- `npm run build -- --silent` blocked locally: dependencies are not installed, so `rollup` is unavailable in PATH.

/claim